### PR TITLE
Drop ruby 2.x support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
         ruby:
           - "2.7.7"
           - "3.0.6"
-          - "3.1.4"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.8"
           - "3.0.6"
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +28,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.8"
+          - "3.0.6"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,11 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.5"
-          - "3.0.3"
+          - "2.7.7"
+          - "3.0.6"
+          - "3.1.4"
+          - "3.2.3"
+          - "3.3.0"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -23,12 +26,13 @@ jobs:
         bundler-cache: true
     - name: Run rspec
       run: bundle exec rake test
+
   rubocop:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
-          - "2.7.5"
+          - "2.7.7"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.7"
+          - "2.7.8"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
           - "2.7.7"
           - "3.0.6"
           - "3.1.4"
-          - "3.2.3"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7.7"
+          - "2.7.8"
           - "3.0.6"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
           - "3.0.6"
           - "3.1.4"
           - "3.2.3"
-          - "3.3.0"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -9,7 +9,6 @@ RAILS_VERSIONS = %w[
   6.0.6.1
   6.1.7.6
   7.0.8
-  7.1.3
 ].freeze
 
 RAILS_FLAGS = %w[

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -6,9 +6,10 @@ require 'bundler'
 require 'open3'
 
 RAILS_VERSIONS = %w[
-  6.0.4.4
-  6.1.4.4
-  7.0.1
+  6.0.6.1
+  6.1.7.6
+  7.0.8
+  7.1.3
 ].freeze
 
 RAILS_FLAGS = %w[


### PR DESCRIPTION
Drop ruby 2.x support due to lack of nokogiri support.