### PR TITLE
Support Rails 7.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
 
 Style/ClassAndModuleChildren:
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,4 @@ end
 task default: :test
 
 path = File.expand_path(__dir__)
-Dir.glob("#{path}/lib/diffcrypt/tasks/**/*.rake").each { |f| load f }
+Dir.glob("#{path}/lib/diffcrypt/tasks/**/*.rake").each { load(_1) }

--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,4 @@ end
 task default: :test
 
 path = File.expand_path(__dir__)
-Dir.glob("#{path}/lib/diffcrypt/tasks/**/*.rake").sort.each { |f| load f }
+Dir.glob("#{path}/lib/diffcrypt/tasks/**/*.rake").each { |f| load f }

--- a/diffcrypt.gemspec
+++ b/diffcrypt.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Diffable encrypted configuration files that can be safely committed into a git repository'
   spec.homepage      = 'https://github.com/diffcrypt/diffcrypt-ruby'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 

--- a/diffcrypt.gemspec
+++ b/diffcrypt.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = %w[diffcrypt]
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 6.0', '< 7.2'
+  spec.add_runtime_dependency 'activesupport', '>= 6.0', '< 7.3'
   spec.add_runtime_dependency 'thor', '>= 0.20', '< 2'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -6,9 +6,10 @@ require 'bundler'
 require 'open3'
 
 RAILS_VERSIONS = %w[
-  6.1.7.7
-  7.0.8.3
-  7.1.3.3
+  6.1.7.8
+  7.0.8.4
+  7.1.4
+  7.2.1
 ].freeze
 
 RAILS_FLAGS = %w[


### PR DESCRIPTION
- Supporting Rails 7.2
- Dropping Ruby 2 support in Rubocop and Gemspec (3.0.0 is minimum now)